### PR TITLE
fix remove btn not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Occasionally when trying to remove a product from the wish list it doesn't work.
+
 ## [1.7.7] - 2021-06-03
 
 ### Fixed

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -313,6 +313,13 @@ const AddBtn: FC = () => {
     if (data.checkList.inList && wishListed.indexOf(productId) === -1) {
       addWishlisted(productId)
     }
+  } else if (
+    data?.checkList?.inList === false &&
+    wishListed.length !== 0 && wishListed.indexOf(productId) !== -1
+  ) {
+    const indexWishListed = wishListed.indexOf(productId)
+    wishListed.splice(indexWishListed, 1);
+    localStore.setItem('wishlist_wishlisted', JSON.stringify(wishListed))
   }
 
   return (


### PR DESCRIPTION
Occasionally it is occurring that when removing a favorite product from the wish list, it is not removed. This is because in the sessionStorage an id of the product that has already been deleted is stored, but when you try to delete it it does not stop because it no longer exists for the user's account.
In this image you can see a product that is added to the wish list, but when you try to remove it, you cannot and this error appears.
![error-wishlist](https://user-images.githubusercontent.com/46789400/120700263-135dd180-c477-11eb-8778-bb2e52663184.png)

This sometimes occurs when the user is interacting with the page having two tabs in the browser.