### PR TITLE
Feature/toast link configurable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -159,6 +159,23 @@ If you want to configure the layout without the `slider-layout` dependency, you 
 | :-------: | :------: | :---------------------------------------------------------: | :-----------: |
 |  `label`  | `string` | Change the label for the section menu under My Account page |  `Wishlist`   |
 
+
+## Custom toast URL
+Change the link of toast message
+
+````` json
+{
+  "add-to-list-btn#myButton": {
+    "props": {
+      "toastURL": "/wishlist"
+    }
+  }
+}
+`````
+| Prop name |   Type   |                         Description                         | Default value |
+| :-------: | :------: | :---------------------------------------------------------: | :-----------: |
+|  `toastURL`  | `string` | Change the link of toast message |  `/account/#wishlist'`   |
+
 ## Customization
 
 In order to apply CSS customizations to this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -24,6 +24,10 @@ import styles from './styles.css'
 const localStore: any = storageFactory(() => sessionStorage)
 const CSS_HANDLES = ['wishlistIconContainer', 'wishlistIcon'] as const
 
+interface AddBtnProps {
+  toastURL: string
+}
+
 let isAuthenticated =
   JSON.parse(String(localStore.getItem('wishlist_isAuthenticated'))) ?? false
 let shopperId = localStore.getItem('wishlist_shopperId') ?? null
@@ -106,7 +110,8 @@ const addWishlisted = (productId: any) => {
   localStore.setItem('wishlist_wishlisted', JSON.stringify(wishListed))
 }
 
-const AddBtn: FC = () => {
+
+const AddBtn: FC<AddBtnProps> = ({ toastURL='/account/#wishlist' }) => {
   const intl = useIntl()
   const [state, setState] = useState<any>({
     isLoading: true,
@@ -150,7 +155,7 @@ const AddBtn: FC = () => {
 
   const [productId] = String(product?.productId).split('-')
 
-  const toastMessage = (messsageKey: string) => {
+  const toastMessage = (messsageKey: string, linkWishlist: string) => {
     let action: any
     if (messsageKey === 'notLogged') {
       action = {
@@ -169,7 +174,7 @@ const AddBtn: FC = () => {
         label: intl.formatMessage(messages.seeLists),
         onClick: () =>
           navigate({
-            to: '/account/#wishlist',
+            to: linkWishlist,
             fetchPage: true,
           }),
       }
@@ -190,13 +195,13 @@ const AddBtn: FC = () => {
           isWishlisted: true,
         }
         addWishlisted(productId)
-        toastMessage('productAddedToList')
+        toastMessage('productAddedToList', toastURL)
       },
     }
   )
 
   if (addError) {
-    toastMessage('addProductFail')
+    toastMessage('addProductFail', toastURL)
   }
 
   if (sessionResponse) {
@@ -332,6 +337,17 @@ const AddBtn: FC = () => {
       </div>
     </NoSSR>
   )
+}
+
+AddBtn.schema = {
+  title: 'Toast Link',
+  type: 'object',
+  properties: {
+    toastURL: {
+      title: 'Toast Link',
+      type: 'string',
+    },
+  }
 }
 
 export default AddBtn

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   SyntheticEvent,
 } from 'react'
+import PropTypes from 'prop-types'
 import { useMutation, useLazyQuery } from 'react-apollo'
 import { defineMessages, useIntl } from 'react-intl'
 import { ProductContext } from 'vtex.product-context'
@@ -24,7 +25,7 @@ import styles from './styles.css'
 const localStore: any = storageFactory(() => sessionStorage)
 const CSS_HANDLES = ['wishlistIconContainer', 'wishlistIcon'] as const
 
-interface AddBtnProps {
+type AddBtnProps = {
   toastURL: string
 }
 
@@ -297,7 +298,7 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL='/account/#wishlist' }) => {
       }
     } else {
       localStore.setItem('wishlist_addAfterLogin', String(productId))
-      toastMessage('notLogged')
+      toastMessage('notLogged',toastURL)
     }
   }
 
@@ -339,15 +340,8 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL='/account/#wishlist' }) => {
   )
 }
 
-AddBtn.schema = {
-  title: 'Toast Link',
-  type: 'object',
-  properties: {
-    toastURL: {
-      title: 'Toast Link',
-      type: 'string',
-    },
-  }
+AddBtn.propTypes = {
+  toastURL: PropTypes.string.isRequired,
 }
 
 export default AddBtn


### PR DESCRIPTION
# Overview

The URL of Toast message not is configurable

# Proposed Solution

Add prop to component AddBtn with default value '/account/#wishlist' to continue being compatible
