### PR TITLE
Feature/product click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add pixel in ProductSummaryWishlist to trigger productClick analytics event
+
 ## [1.9.2] - 2021-09-29
 
 ### Added

--- a/react/ProductSummaryWishlist.tsx
+++ b/react/ProductSummaryWishlist.tsx
@@ -5,6 +5,7 @@ import { ExtensionPoint, useRuntime, useTreePath } from 'vtex.render-runtime'
 import { useListContext, ListContextProvider } from 'vtex.list-context'
 import { ProductListContext } from 'vtex.product-list-context'
 import { Spinner } from 'vtex.styleguide'
+import { usePixel } from 'vtex.pixel-manager'
 
 import { mapCatalogProductToProductSummary } from './utils/normalize'
 import ProductListEventCaller from './components/ProductListEventCaller'
@@ -51,6 +52,7 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
   const { list } = useListContext() || []
   const { treePath } = useTreePath()
   const { navigate, history } = useRuntime()
+  const { push } = usePixel()
 
   const sessionResponse: any = useSessionResponse()
 
@@ -127,12 +129,23 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
           }
         }
       }
+
+      const handleOnClick = () =>{
+        push({
+          event: 'productClick',
+          list: 'wishlist',
+          product: normalizedProduct,
+          position: index,
+        })
+      }
+
       return (
         <ExtensionPoint
           id="product-summary"
           key={product.id}
           treePath={treePath}
           product={normalizedProduct}
+          actionOnClick={handleOnClick}
         />
       )
     })

--- a/react/ProductSummaryWishlist.tsx
+++ b/react/ProductSummaryWishlist.tsx
@@ -117,6 +117,7 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
     const componentList = products?.map((product: any, index: any) => {
       const sku = dataLists?.viewLists[0]?.data[index]?.sku
       const items = data?.productsByIdentifier[index]?.items
+      const position = index + 1
 
       const normalizedProduct = mapCatalogProductToProductSummary(
         product,
@@ -135,7 +136,7 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
           event: 'productClick',
           list: 'wishlist',
           product: normalizedProduct,
-          position: index,
+          position,
         })
       }
 


### PR DESCRIPTION
Hi VTEX team,

I am asking for a pull request to add a **productClick** analytics event when the user clicks on the product card in the wishlist. 
The productClick event already exists in [ProductSummaryList.tsx](https://github.com/vtex-apps/product-summary/blob/master/react/ProductSummaryList.tsx).

Below you can see the **producClick** event being fired when user clicks on the product card.

<img width="1145" alt="productClickExample" src="https://user-images.githubusercontent.com/39059002/145850799-93fdc925-269b-4745-8b8d-fd15eacff275.png">

You can check my implementation at:
**Workspace:** https://wishlistprodclick3--itwhirlpool.myvtex.com/
**To get to wishlist page:** https://wishlistprodclick3--itwhirlpool.myvtex.com/account#/wishlist

Thank you for your time.
