### PR TITLE
[WISHLISTS-25] fix the wishlist api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the api for downloading all the wishlist records
+
 ## [1.10.0] - 2022-01-28
 
 ### Added

--- a/dotnet/Controlers/RoutesController.cs
+++ b/dotnet/Controlers/RoutesController.cs
@@ -26,12 +26,7 @@
         public async Task<IActionResult> ExportAllLists()
         {
             WishListsWrapper wishListsWrapper = await _wishListRepository.GetAllLists();
-            var queryString = HttpContext.Request.Query;
-            int from = int.Parse(queryString["from"]);
-            int to = int.Parse(queryString["to"]);
-            IList<WishListWrapper> wishListsWrappers = wishListsWrapper.WishLists;
-            wishListsWrapper.WishLists = wishListsWrappers.Skip(from - 1).Take(to - from).ToList();
-
+            
             return Json(wishListsWrapper);
         }
     }

--- a/dotnet/Data/WishListRepository.cs
+++ b/dotnet/Data/WishListRepository.cs
@@ -240,7 +240,7 @@
             }
         }
 
-        private async Task<string> firstScroll()
+        private async Task<string> FirstScroll()
         {
             var client = _clientFactory.CreateClient();
             var request = new HttpRequestMessage
@@ -266,7 +266,7 @@
             return responseContent;
         }
 
-        private async Task<string> subScroll()
+        private async Task<string> SubScroll()
         {
             var client = _clientFactory.CreateClient();
             var request = new HttpRequestMessage
@@ -300,13 +300,13 @@
             {
                 if( i == 0)
                 {
-                    var res = await firstScroll();
+                    var res = await FirstScroll();
                     JArray resArray = JArray.Parse(res);
                     searchResult.Merge(resArray);
                 }
                 else
                 {
-                    var res = await subScroll();
+                    var res = await SubScroll();
                     JArray resArray = JArray.Parse(res);
                     if (resArray.Count < 200) 
                     {

--- a/react/WishlistAdmin.tsx
+++ b/react/WishlistAdmin.tsx
@@ -18,15 +18,6 @@ const WishlistAdmin: FC<any> = ({ intl }) => {
 
   const { loading } = state
 
-  const fetchWishlists = async (from: number, to: number) => {
-    const response: any = await fetch(
-      `/_v/wishlist/export-lists?from=${from}&to=${to}`,
-      { mode: 'no-cors' }
-    )
-
-    return response.json()
-  }
-
   const downloadWishlist = (allWishlists: any) => {
     const header = ['Email', 'Product ID', 'SKU', 'Title']
     const data: any = []
@@ -54,28 +45,15 @@ const WishlistAdmin: FC<any> = ({ intl }) => {
     XLSX.writeFile(wb, exportFileName)
   }
 
-  let allWishlists: any = []
-
   const getAllWishlists = async () => {
-    let status = true
-    let i = 0
-    const chunkLength = 100
     setState({ ...state, loading: true })
 
-    while (status) {
-      await fetchWishlists(i, i + chunkLength).then(data => {
-        const wishlistArr = data.wishLists
+    const data: any = await fetch(`/_v/wishlist/export-lists`).then(response =>
+      response.json()
+    )
+    const wishlistArr = data.wishLists
 
-        if (!wishlistArr.length) {
-          status = false
-        }
-        allWishlists = [...allWishlists, ...wishlistArr]
-      })
-
-      i += 100
-    }
-
-    downloadWishlist(allWishlists)
+    downloadWishlist(wishlistArr)
     setState({ ...state, loading: false })
   }
 


### PR DESCRIPTION
What problem is this solving?

Bugfix for the wishlist API, the wishlist API is using the _scroll api_ . There were no subsequent scroll requests so the API couldn't return all the wishlist records. This change sets the scroll size to 200 so that the scroll will return 200 records in each call.

How to test it?

Add a product to your wishlist so that your record will be the most recent one. Then download the wishlist sheet and search to see if your newest record is there. 