### PR TITLE
[WISHLIST-25] Fix products added before login not display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix products added to wishlist before logging in are not displayed
+
 ## [1.11.1] - 2022-03-01
-
-## [1.11.0] - 2022-02-25
-
 ### Added
 
 - Added URL information in README file for the user
+
+## [1.11.0] - 2022-02-25
 
 ### Fixed
 

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -255,6 +255,7 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
           listItem: {
             productId,
             title: product.productName,
+            sku: selectedItem.itemId,
           },
           shopperId,
           name: defaultValues.LIST_NAME,


### PR DESCRIPTION
What problem is this solving?

Fix the bug about products added to the wishlist before logging in are not displayed

How to test it?

First login to linked workspace,
then logout and add a product to the wishlist (there will be a notification about asking you to log in)
then login again from the notification,
check your wishlist page to see if the product you add is there. 