### PR TITLE
[WISHLIST-34] fix favorited & duplicate check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix favorited check and stop duplicate item added to same list
+
 ## [1.11.2] - 2022-03-02
 
 ### Fixed

--- a/dotnet/Services/WishListService.cs
+++ b/dotnet/Services/WishListService.cs
@@ -107,6 +107,13 @@ namespace WishList.Services
             {
                 _context.Vtex.Logger.Debug("SaveItem", null, $"Saving '{shopperId}' '{listName}' {listItemsWrapper.ListItems.Count} existing items.");
                 listItemsToSave = listItemsWrapper.ListItems;
+                foreach (ListItem item in listItemsToSave)
+                {
+                    if (listItem.ProductId ==  item.ProductId)
+                    {
+                        listItem.Id = item.Id;
+                    }
+                }
                 if(listItem.Id == null)
                 {
                     int maxId = 0;

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -278,9 +278,8 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
     return sessionResponse?.namespaces?.profile?.isAuthenticated?.value ===
       'false'
       ? false
-      : wishListed.find(
-          (item: any) => item.productId === productId && item.sku === sku
-        ) !== undefined
+      : wishListed.find((item: any) => item.productId === productId) !==
+          undefined
   }
 
   const handleAddProductClick = (e: SyntheticEvent) => {


### PR DESCRIPTION
What problem is this solving?

bugfix for product page favorited check and fix the duplicate item added to the same list

How to test it?

1. Go to any workspace that has this update linked
2. Login with an account that has saved products on the wishlist. 
3. Save any item and go to the wishlist page.
4. Enter to the product you just added and validate the heart icon (it should be a favorited heart)

If you don't see a favorited heart, please contact me.