### PR TITLE
[WISHLIST38] Set timeout to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Set timeout to 60s to avoid proxy time out error when downloading a large amount of data
+
+### Fixed
+
 - Add immediate indexing to the schema to solve masterdata delay update
 
 ## [1.11.4] - 2022-03-15

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -1,6 +1,8 @@
 {
   "stack": "dotnet",
   "memory": 256,
+  "timeout": 60,
+  "ttl": 60,
   "runtimeArgs": [
   ],
   "routes": {


### PR DESCRIPTION
What problem is this solving?

For account `Compracerta` has a large amount of wishlist data, the download threw proxy timeout errors. This PR set the timeout to 60s and the ttl to 60s to avoid the proxy timeout.