### PR TITLE
[WISHLIST-43] fix localStore update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix updating removed wishlist item in localstorage
+
 ## [1.12.1] - 2022-03-29
 
 ### Fixed

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -351,6 +351,23 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
     }
   }
 
+  if (
+    data?.checkList?.inList !== true &&
+    productCheck[productId] === undefined &&
+    wishListed.find(
+      (item: any) => item.productId === productId && item.sku === sku
+    ) !== undefined
+  ) {
+    wishListed = wishListed.filter(
+      (item: any) => item.productId !== productId && item.sku !== sku
+    )
+    saveToLocalStorageItem(wishListed)
+    setState({
+      ...state,
+      isWishlistPage: false,
+    })
+  }
+
   return (
     <NoSSR>
       <div className={handles.wishlistIconContainer}>


### PR DESCRIPTION
What does this PR do? 

Fix the bug about updating removed wishlist items in localStore

How to test it? 
[https://aurora--compracerta.myvtex.com/](url)
1. login into the workspace page
2. add an item to your wishlist and open two tabs of this product
3. unfavorited this item on one page, and go to another page and refresh
4. you should see the item is also unfavorited on the second page
