### PR TITLE
[WISHLIST-36] Fix custom empty wishlist display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix custom empty wishlist component display when viewed by users who have yet to interact with the wishlist
+
 ## [1.13.0] - 2022-04-29
 
 ### Fixed

--- a/react/ProductSummaryWishlist.tsx
+++ b/react/ProductSummaryWishlist.tsx
@@ -94,13 +94,14 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
     }
   }
   let productList = [] as any
-  productList = dataLists?.viewLists[0]?.data.map((item: any) => {
-    const [id] = item.productId.split('-')
-    return {
-      productId: id,
-      sku: item.sku,
-    }
-  }) ?? []
+  productList =
+    dataLists?.viewLists[0]?.data.map((item: any) => {
+      const [id] = item.productId.split('-')
+      return {
+        productId: id,
+        sku: item.sku,
+      }
+    }) ?? []
   if (!called && dataLists && productList) {
     const ids = productList.map((item: any) => item.productId)
     localStore.setItem('wishlist_wishlisted', JSON.stringify(productList))

--- a/react/ProductSummaryWishlist.tsx
+++ b/react/ProductSummaryWishlist.tsx
@@ -100,7 +100,7 @@ const ProductSummaryList: FC<ProductSummaryProps> = ({
       productId: id,
       sku: item.sku,
     }
-  })
+  }) ?? []
   if (!called && dataLists && productList) {
     const ids = productList.map((item: any) => item.productId)
     localStore.setItem('wishlist_wishlisted', JSON.stringify(productList))


### PR DESCRIPTION
Default `productList` to empty list if there's no `dataLists` or `viewLists`. Users who've already used the wishlist then empty it out seem to have an empty list for `productList`. Users who create a new account or have never used wishlist have `undefined` for `productList`. When that happens, logic gets caught to return `null` instead of empty wishlist component.

Workspace: [annawishlist](https://annawishlist--sandboxusdev.myvtex.com/)

Steps to Test:
1. Create a new account in sandboxusdev
2. Go to account's `/wishlist` page in workspace
3. See message from `wishlist-empty-list` block