### PR TITLE
[WISHLIST-49] Add specificationGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added specificationGroups values for the productsByIdentifier query
+
 ## [1.13.1] - 2022-05-10
 
 ### Fixed

--- a/react/queries/productById.gql
+++ b/react/queries/productById.gql
@@ -69,6 +69,16 @@ query productsByIdentifier($ids: [ID!]) {
         minQuantity
       }
     }
+    specificationGroups {
+      originalName
+      name
+      specifications {
+        originalName
+        name
+        values
+      }
+
+    }
     priceRange {
       sellingPrice {
         highPrice


### PR DESCRIPTION
What problem does this PR solve?

Previously, the `productsByIdentifier` query does not return specificationGroups, this PR added the specificationGroups values

How to test?
Go to the client's environment [workspace](https://nicoprueba--discouy.myvtex.com/account#/wishlist)
Log in and add a couple of items to your wishlist, you should be able to see the items.