### PR TITLE
[WISHLIST-62] Fix filled heart for unfavorited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed lazyload inlist data cause unfavorited item shows favorited without refresh
+
+### Fixed
+
 - Fixed the return url after login to include the search field
 
 ### Changed

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -346,7 +346,9 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
         (item: any) => item.productId === productId && item.sku === sku
       ) === undefined
     ) {
-      addWishlisted(productId, sku)
+      if (productId && sku) {
+        addWishlisted(productId, sku)
+      }
     }
   }
 


### PR DESCRIPTION
What problem does this PR solve?

Previously, items not wishlisted will show wishlisted in the following scenario:

 1. login to the site and make sure you have items on your wishlist
 2. click and open the page of one of the favorite item from your wishlist page
 3. you will see the heart is filled for this item. And scroll down to see other suggested items, and click and open the page for an unfavorited item
 4. Now you will see the heart is filled for that unfavorited item.

This PR fixes the bug by adding a condition to add an item to the wishlist

How to test it:

[Workspace](https://aurora--zinco.myvtex.com)