### PR TITLE
wishlist_private-export-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change export-list Api to private for preventing data leak
+
 ### Changed
 
 - Cypress code improvements

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -8,7 +8,13 @@
   "routes": {
     "ExportAllLists": {
       "path": "/_v/wishlist/export-lists",
-      "public": true
+      "public": false,
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["get"]
+        }
+      ]
     }
   },
   "events": {


### PR DESCRIPTION
**What problem is this solving?**
 
The export-list API was public and it caused data leak, this PR set it to private and it will ask VtexIdclientAutCookie to access

How to test it?
[Workspace](https://aurora--jefferspet.myvtex.com/)
[API](https://app.io.vtex.com/vtex.wish-list/v1/jefferspet/aurora/_v/wishlist/export-lists)
https://app.io.vtex.com/vtex.wish-list/v1/jefferspet/aurora/_v/wishlist/export-lists
