### PR TITLE
feat(acessibility): added aria-label property to resolve accessibility

### DIFF
--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -378,6 +378,7 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
           isLoading={loading || addLoading || removeLoading}
         >
           <span
+            aria-label={intl.formatMessage(messages.addButton)}
             className={`${handles.wishlistIcon} ${
               checkFill() ? styles.fill : styles.outline
             } ${styles.iconSize}`}


### PR DESCRIPTION
**What problem is this solving?**

Adicionado a propriedade `aria-label` para melhorar a experiência e resolver os alertas de acessibilidade da regra que [botões precisam ter um nome acessível](https://dequeuniversity.com/rules/axe/4.8/button-name), apontados pelo Lighthouse.

**How to test it?**

[Workspace](https://www.samsclub.com.br/vinhos?workspace=accessibilityplp)

Executar teste no Lighthouse ou PageSpeed.

**Screenshots or example usage:**

Antes da alteração: 
![image](https://github.com/vtex-apps/wish-list/assets/12280996/cd4d2a27-dab1-42e7-9e68-70593f95a26d)

Depois da alteração:

Após a adição do `aria-label`, o Lighthouse não apontou mais o problema:
![image](https://github.com/vtex-apps/wish-list/assets/12280996/f09c0163-5633-456d-b080-bbfa55925f98)

