### PR TITLE
Fix login button redirection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+
+- change redirection method of the login button click event
+
 ## [1.18.3] - 2024-09-17
 
 ### Fix

--- a/react/AddProductBtn.tsx
+++ b/react/AddProductBtn.tsx
@@ -171,13 +171,11 @@ const AddBtn: FC<AddBtnProps> = ({ toastURL = '/account/#wishlist' }) => {
       action = {
         label: intl.formatMessage(messages.login),
         onClick: () =>
-          navigate({
-            page: 'store.login',
-            query: `returnUrl=${encodeURIComponent(
+          window.location.assign(`/login?returnUrl=${encodeURIComponent(
               String(history?.location?.pathname) +
                 String(history?.location?.search)
             )}`,
-          }),
+          ),
       }
     }
     if (messsageKey === 'productAddedToList') {

--- a/react/MyAcccountWishlistPage.tsx
+++ b/react/MyAcccountWishlistPage.tsx
@@ -6,7 +6,6 @@ type MyAccountWishlistPageProps = {
   children: FC
   title?: string
   namespace?: string
-  
 }
 const MyAccountWishlistPage = ({
   children,

--- a/react/MyAcccountWishlistPage.tsx
+++ b/react/MyAcccountWishlistPage.tsx
@@ -6,6 +6,7 @@ type MyAccountWishlistPageProps = {
   children: FC
   title?: string
   namespace?: string
+  
 }
 const MyAccountWishlistPage = ({
   children,


### PR DESCRIPTION
I found that the `navigate` method that comes from the `useRuntime` hook that is imported from `vtex.render-runtime` changes encoded query parameter to decoded and this cause a problem with loose of query parameters that comes inside of the `returnUrl` parameter.
To fix this issue I changed the `navigate` method to the js native `window.location.assign`